### PR TITLE
refactor(client): make HttpClient visible to deriving class of `BaseAPI

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -24,7 +24,6 @@ export interface ClientOptions extends HttpClientOptions {}
 export interface Client {
   name: string;
   options: ClientOptions;
-  readonly httpClient: HttpClient;
 }
 
 /**

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -16,12 +16,13 @@
  */
 
 import { Client, HttpClient } from '../client';
+import { GelatoClient } from '../client/gelato-client';
 
 /** @internal */
 export abstract class BaseAPI {
-  private readonly client_: Client;
+  private readonly client_: GelatoClient;
 
-  constructor(client: Client) {
+  constructor(client: GelatoClient) {
     this.client_ = client;
   }
 
@@ -29,7 +30,7 @@ export abstract class BaseAPI {
     return this.client_;
   }
 
-  get httpClient(): HttpClient {
+  protected get httpClient(): HttpClient {
     return this.client_.httpClient;
   }
 }

--- a/src/services/orders/orders-api.ts
+++ b/src/services/orders/orders-api.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Client } from '../../client';
+import { GelatoClient } from '../../client/gelato-client';
 import { BaseAPI } from '../api-service';
 import {
   getOrderCancelURL,
@@ -44,7 +44,7 @@ import {
  * @publicApi
  */
 export class OrdersAPI extends BaseAPI {
-  constructor(client: Client) {
+  constructor(client: GelatoClient) {
     super(client);
   }
 

--- a/src/services/products/products-api.ts
+++ b/src/services/products/products-api.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Client } from '../../client';
+import { GelatoClient } from '../../client/gelato-client';
 import { BaseAPI } from '../api-service';
 
 import { GetCatalogResponse, GetCatalogsResponse } from './catalog';
@@ -43,7 +43,7 @@ import { GetStockAvailabilityResponse } from './stock-availability';
  * @publicApi
  */
 export class ProductsAPI extends BaseAPI {
-  constructor(client: Client) {
+  constructor(client: GelatoClient) {
     super(client);
   }
 

--- a/src/services/shipment/shipment-api.ts
+++ b/src/services/shipment/shipment-api.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import { Client } from '../../client';
 import { BaseAPI } from '../api-service';
 
-import { GetShipmentMethodsQueryParams, GetShipmentMethodsResponse } from './shipment';
+import { GelatoClient } from '../../client/gelato-client';
 import { getShipmentMethodsURL } from './constants';
+import { GetShipmentMethodsQueryParams, GetShipmentMethodsResponse } from './shipment';
 
 /**
  * @description
@@ -31,7 +31,7 @@ import { getShipmentMethodsURL } from './constants';
  * @publicApi
  */
 export class ShipmentAPI extends BaseAPI {
-  constructor(client: Client) {
+  constructor(client: GelatoClient) {
     super(client);
   }
 


### PR DESCRIPTION
Prevent classes other than those deriving from `BaseAPI` to expose the underlying HttpClient. This is because we don't want anyone to be messing with the required presets of request configs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The `BaseAPI` exposes the underlying `HttpClient` to all subclasses extending it.
This behavior is undesirable since we don't want people to change some underlying
configurations of the HttpClient.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Only direct child classes extending from the `BaseAPI` service can access the
`HttpClient`.
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A