### PR TITLE
refactor(services): remove redundant constructor from API services

### DIFF
--- a/src/services/orders/orders-api.ts
+++ b/src/services/orders/orders-api.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { GelatoClient } from '../../client/gelato-client';
 import { BaseAPI } from '../api-service';
+
 import {
   getOrderCancelURL,
   getOrderQuoteURL,
@@ -44,10 +44,6 @@ import {
  * @publicApi
  */
 export class OrdersAPI extends BaseAPI {
-  constructor(client: GelatoClient) {
-    super(client);
-  }
-
   /**
    * Retrieve a list of orders.
    * @param filter An object containing filter properties to customize the query.

--- a/src/services/products/products-api.ts
+++ b/src/services/products/products-api.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { GelatoClient } from '../../client/gelato-client';
 import { BaseAPI } from '../api-service';
 
 import { GetCatalogResponse, GetCatalogsResponse } from './catalog';
@@ -43,10 +42,6 @@ import { GetStockAvailabilityResponse } from './stock-availability';
  * @publicApi
  */
 export class ProductsAPI extends BaseAPI {
-  constructor(client: GelatoClient) {
-    super(client);
-  }
-
   /**
    * Retrieve a list of available catalogs.
    * @returns A promise resolving with a list of `Catalog` objects.

--- a/src/services/shipment/shipment-api.ts
+++ b/src/services/shipment/shipment-api.ts
@@ -17,7 +17,6 @@
 
 import { BaseAPI } from '../api-service';
 
-import { GelatoClient } from '../../client/gelato-client';
 import { getShipmentMethodsURL } from './constants';
 import { GetShipmentMethodsQueryParams, GetShipmentMethodsResponse } from './shipment';
 
@@ -31,10 +30,6 @@ import { GetShipmentMethodsQueryParams, GetShipmentMethodsResponse } from './shi
  * @publicApi
  */
 export class ShipmentAPI extends BaseAPI {
-  constructor(client: GelatoClient) {
-    super(client);
-  }
-
   /**
    * Get information about each shipment method that Gelato provides.
    * The shipping methods can be filtered on shipment destination country.


### PR DESCRIPTION
The `BaseAPI` class already provides a constructor, while deriving service classes do not provide other constructor parameters.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
All APIs services implement the `BaseAPI` class and use a constructor without
providing other constructor parameters, thus making the usage of a constructor
unnecessary.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
All API services have their constructors removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A