### PR TITLE
style: fix endOfLine lint/formatting warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": ["eslint:recommended", "plugin:node/recommended", "prettier"],
   "plugins": ["node", "prettier"],
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "block-scoped-var": "error",
     "eqeqeq": "error",
     "no-var": "error",


### PR DESCRIPTION
Due to differences in how line breaks are handled on Windows & Linux, the eslint/prettier VSCode plugin complains when the operating system's handle for line breaks do not match the `endOfLine` configuration in the `.eslintrc.json` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The `eslint-config-prettier` emits lint errors when the platform-specific handle for
line breaks do not match the default eslint prettier config. This is undesirable since
it should auto-detect the operating systems default behavior for line breaks.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

See: https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-eslint-delete-cr-prettier-prettier
