### PR TITLE
fix(orders): use accepted HTTP method to `getOrders`

### DIFF
--- a/src/services/orders/orders-api.ts
+++ b/src/services/orders/orders-api.ts
@@ -55,7 +55,10 @@ export class OrdersAPI extends BaseAPI {
    * @returns A promise resolving with a list of orders found.
    */
   getOrders(filter: SearchOrdersRequest = {}): Promise<SearchOrdersResponse> {
-    return this.httpClient.get<SearchOrdersResponse>(SEARCH_ORDERS_URL, { params: filter });
+    return this.httpClient.post<SearchOrdersResponse, SearchOrdersRequest>(
+      SEARCH_ORDERS_URL,
+      filter,
+    );
   }
 
   /**


### PR DESCRIPTION
In commit #f5fb8db we replaced the *GET* with *POST* method to retrieve a list of orders. This change resulted in an `405` http status code.

This commit reverts this change.

The Gelato API seems to use, although counter-intuitively, a `POST` HTTP method to *get* a list of orders.

I don't quit understand why you would do that, since it completely undermines proven practices in designing REST APIs.

Fixes: #38

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
We basically cannot retrieve a list of orders, since we use the 'wrong' HTTP method.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Calling `OrdersAPI#getOrders()` now returns a list of orders.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
