### PR TITLE
refactor: rename `BaseAPI` to `ApiService`

### DIFF
--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -18,8 +18,7 @@
 import { Client, HttpClient } from '../client';
 import { GelatoClient } from '../client/gelato-client';
 
-/** @internal */
-export abstract class BaseAPI {
+export class ApiService {
   private readonly client_: GelatoClient;
 
   constructor(client: GelatoClient) {

--- a/src/services/orders/orders-api.ts
+++ b/src/services/orders/orders-api.ts
@@ -16,7 +16,7 @@
  */
 
 import { combineURLs } from '../../utils/urls';
-import { BaseAPI } from '../api-service';
+import { ApiService } from '../api-service';
 import {
   CreateOrderRequest,
   GetOrderResponse,
@@ -48,7 +48,7 @@ const cancelOrderURL = (orderId: string) => combineURLs(GET_ORDERS_URL, `${order
  *
  * @publicApi
  */
-export class OrdersAPI extends BaseAPI {
+export class OrdersAPI extends ApiService {
   /**
    * Retrieve a list of orders.
    * @param filter An object containing filter properties to customize the query.

--- a/src/services/products/products-api.ts
+++ b/src/services/products/products-api.ts
@@ -16,7 +16,7 @@
  */
 
 import { combineURLs } from '../../utils/urls';
-import { BaseAPI } from '../api-service';
+import { ApiService } from '../api-service';
 import { GetCatalogResponse, GetCatalogsResponse } from './catalog';
 import { GetCoverDimensionsResponse } from './cover-dimensions';
 import { GetPricesResponse } from './prices';
@@ -60,7 +60,7 @@ const getProductCoverDimensionsURL = (productId: string) => {
  *
  * @publicApi
  */
-export class ProductsAPI extends BaseAPI {
+export class ProductsAPI extends ApiService {
   /**
    * Retrieve a list of available catalogs.
    * @returns A promise resolving with a list of `Catalog` objects.

--- a/src/services/shipment/shipment-api.ts
+++ b/src/services/shipment/shipment-api.ts
@@ -16,7 +16,7 @@
  */
 
 import { combineURLs } from '../../utils/urls';
-import { BaseAPI } from '../api-service';
+import { ApiService } from '../api-service';
 import { GetShipmentMethodsQueryParams, GetShipmentMethodsResponse } from './shipment';
 
 const SHIPMENT_ROOT_URL = 'https://shipment.gelatoapis.com/v1';
@@ -32,7 +32,7 @@ const SHIPMENT_METHODS_URL = combineURLs(SHIPMENT_ROOT_URL, 'shipment-methods');
  *
  * @publicApi
  */
-export class ShipmentAPI extends BaseAPI {
+export class ShipmentAPI extends ApiService {
   /**
    * Get information about each shipment method that Gelato provides.
    * The shipping methods can be filtered on shipment destination country.

--- a/test/e2e/gelato-admin.spec.ts
+++ b/test/e2e/gelato-admin.spec.ts
@@ -20,7 +20,7 @@ import dotenv from 'dotenv';
 import { initializeClient } from '../../src/client';
 import { GelatoClient } from '../../src/client/gelato-client';
 import { DEFAULT_CLIENT_NAME } from '../../src/client/lifecycle';
-import { BaseAPI } from '../../src/services/api-service';
+import { ApiService } from '../../src/services/api-service';
 import {
   GetOrderResponse,
   getOrdersAPI,
@@ -324,8 +324,8 @@ describe('Gelato Admin', () => {
 
 function runServiceInitTest(
   name: string,
-  serviceInstance: BaseAPI,
-  expectedType: typeof BaseAPI,
+  serviceInstance: ApiService,
+  expectedType: typeof ApiService,
   env: GelatoEnvConfig,
 ) {
   it(`should return an instance of ${name}`, async () => {


### PR DESCRIPTION
This commit does three things to `api-service.ts`:
- makes the class non-abstract
- renames the class to `ApiService` so that it reflects the contents of the file.
- removes the *internal* jsdoc so that it doesn't get accidentally deleted when building the project. This is because we use the `stripInternal` compilerOptions in tsconfig.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
